### PR TITLE
User configuration for Recording path

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
             "description": "FFmpeg Binary Location",
             "type": "string"
           },
+          "stories.recording-location": {
+            "description": "Recordings Location",
+            "type": "string"
+          },
           "stories.username": {
             "description": "Username that shows up when you post a story",
             "type": "string"

--- a/src/config.ts
+++ b/src/config.ts
@@ -51,7 +51,10 @@ export class Config {
   }
 
   static async getFilename() {
-    const dir = await this.getDestFolder();
+    const dir = this.hasConfig("recording-location") 
+    ? this.getConfig("recording-location") as string 
+    : await this.getDestFolder();
+
     const folders = vscode.workspace.workspaceFolders;
     const ws = folders
       ? folders![0].name.replace(/[^A-Za-z0-9\-_]+/g, "_")


### PR DESCRIPTION
This PR takes care of #33 the path can now be configured just in case you don't want to clutter your home directory. By default the extension creates a new directory called `Recordings` in your home directory. i.e. ~ It isn't strictly bad, but I like to keep my home directory clean, surely others do the same.

This PR adds a new config input:

![image](https://user-images.githubusercontent.com/10265682/97785762-16a57d80-1b75-11eb-9173-9f1cef23de99.png)

If this value is empty then the extension will work just as before by creating the ~/Recordings directory.

# Examples:

## Same as before

![image](https://user-images.githubusercontent.com/10265682/97785811-6e43e900-1b75-11eb-884d-e3006561b859.png)

## New addition with a different recording location path:

![image](https://user-images.githubusercontent.com/10265682/97785857-a0554b00-1b75-11eb-9f0b-94ae49324a65.png)

![image](https://user-images.githubusercontent.com/10265682/97785890-c4189100-1b75-11eb-87e8-5fc9389ec273.png)

I am unsure if Recordings dir was meant to be deleted after either discarding or uploading, I see that it deletes the mp4 and gif if you discard/upload but keeps the Recordings dir. I guess this recording path might still be a good user config, and maybe the dir deletion needs to be another PR if is needed.



