### PR TITLE
[Feature] Add shortcut keys for basic commands (#64)

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,29 @@
           "name": "Stories"
         }
       ]
-    }
+    },
+    "keybindings": [
+      {
+        "command": "stories.refresh",
+        "key": "ctrl+alt+s r",
+        "mac": "cmd+alt+s r"
+      },
+      {
+        "command": "stories.setFlair",
+        "key": "ctrl+alt+s f",
+        "mac": "cmd+alt+s f"
+      },
+      {
+        "command": "stories.startTextRecording",
+        "key": "ctrl+alt+s s",
+        "mac": "cmd+alt+s s"
+      },
+      {
+        "command": "stories.stopTextRecording",
+        "key": "ctrl+alt+s q",
+        "mac": "cmd+alt+s q"
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "yarn run compile",


### PR DESCRIPTION
This PR adds keybindings for vscode-stories.

This pr resolves #64 

I added keybinds for these four commands:

1. `stories.refresh`
2. `stories.setFlair`
3. `stories.startTextRecording`
4. `stories.stopTextRecording`

I decided that it didn't really make sense to add keybinds for other commands (though I can add easily if needed)

All the keybindings start with the leader `ctrl+alt+s` (`cmd+alt+s` on mac) and then end with a second key to execute the command.

Ex:

`ctrl+alt+s r` : `stories.refresh`

I decided to do this to make sure that these keybinds don't clash with other default keybinds.

NOTE: I am unable to test these changes on a Mac, so if this is going to be merged, I recommend they are also tested on mac (they work fine on windows)