### PR TITLE
Change color of stories' circle

### DIFF
--- a/svelte-stuff/components/StoryBubble.svelte
+++ b/svelte-stuff/components/StoryBubble.svelte
@@ -14,13 +14,11 @@
     align-items: center;
     background-image: linear-gradient(
       45deg,
-      #ffa95f 5%,
-      #f99c4a 15%,
-      #f47838 30%,
-      #e75157 45%,
-      #d92d7a 70%,
-      #cc2a92 80%,
-      #c32e92 95%
+      #00a0f3 15%,
+      #0090d8 35%,
+      #0082d3 50%,
+      #007cc0 65%,
+      #006db4 85%
     );
     box-sizing: border-box;
     display: flex;


### PR DESCRIPTION
_Issue: #75._
I've changed the color of the circle that surrounds the story image.
The colors that I chose were these:

<img src="https://user-images.githubusercontent.com/37962411/98585348-20c22d00-2295-11eb-8b06-963bd4ed3d99.png" alt="VScode stories new circle color" width="414"/>

they're from the VScode logo colors, as I consider they fit better with the common themes on VScode.
There were 7 colors, now are only 5 because I think it's the best approach (as all colors are blue tones.)
Feel free to change anything.
🎨